### PR TITLE
Default keyboard shortcut to open search dialogue

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -39,9 +39,19 @@
   },
   "content_scripts": [
     {
-      "matches": ["http://*/*", "https://*/*", "file://*/*"],
-      "js": ["js/content.js"]
+      "matches": [ "http://*/*", "https://*/*", "file://*/*" ],
+      "js": [ "js/content.js" ]
     }
   ],
+  "commands": {
+    "_execute_browser_action": {
+      "suggested_key": {
+        "windows": "Ctrl+Shift+F",
+        "mac": "Command+Shift+F",
+        "chromeos": "Ctrl+Shift+F",
+        "linux": "Ctrl+Shift+F"
+      }
+    }
+  },
   "options_page": "options.html"
 }


### PR DESCRIPTION
Defaults to Ctrl/Cmd+Shift+F

There are options to change this at:

chrome://extensions/configureCommands

But as far as I could tell chrome doesn't expose any way to add this to the extension's options menu. 