### PR TITLE
Support matches that cross element boundaries

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -3,8 +3,8 @@ var ELEMENT_NODE_TYPE = 1;
 var TEXT_NODE_TYPE = 3;
 var UNEXPANDABLE = /(script|style|svg|audio|canvas|figure|video|select|input|textarea)/i;
 var HIGHLIGHT_TAG = 'highlight-tag';
-var HIGHLIGHT_CLASS = 'highlighted';
-var SELECTED_CLASS = 'selected';
+var HIGHLIGHT_CLASS = 'chrome-regex-search-highlighted';
+var SELECTED_CLASS = 'chrome-regex-search-selected';
 var DEFAULT_MAX_RESULTS = 500;
 var DEFAULT_HIGHLIGHT_COLOR = '#ffff00';
 var DEFAULT_SELECTED_COLOR = '#ff9900';
@@ -14,6 +14,7 @@ var DEFAULT_CASE_INSENSITIVE = false;
 
 /*** VARIABLES ***/
 var searchInfo;
+var finder;
 /*** VARIABLES ***/
                      
 /*** LIBRARY FUNCTIONS ***/
@@ -34,7 +35,7 @@ function initSearchInfo(pattern) {
   searchInfo = {
     regexString : pattern,
     selectedIndex : 0,
-    highlightedNodes : [],
+    highlights : [],
     length : 0
   }
 }
@@ -50,58 +51,30 @@ function returnSearchInfo(cause) {
   });
 }
 
-/* Check if the given node is a text node */
-function isTextNode(node) {
-  return node && node.nodeType === TEXT_NODE_TYPE;
-}
-
-/* Check if the given node is an expandable node that will yield text nodes */
-function isExpandable(node) {
-  return node && node.nodeType === ELEMENT_NODE_TYPE && node.childNodes && 
-         !UNEXPANDABLE.test(node.tagName) && node.visible();
-}
-
 /* Highlight all text that matches regex */
 function highlight(regex, highlightColor, selectedColor, textColor, maxResults) {
-  function highlightRecursive(node) {
-    if(searchInfo.length >= maxResults){
-      return;
+  finder = findAndReplaceDOMText(
+    document.body,
+    {
+      find: regex,
+      wrap: "span",
+      wrapClass: HIGHLIGHT_CLASS,
+      filterElements: function(element) {
+        /* Check if the element is visible */
+        /* https://stackoverflow.com/a/21696585 */
+        return element.offsetParent !== null || element === document.body;
+      },
+      preset: "prose"
     }
-    if (isTextNode(node)) {
-      var index = node.data.search(regex);
-      if (index >= 0 && node.data.length > 0) {
-        var matchedText = node.data.match(regex)[0];
-        var matchedTextNode = node.splitText(index);
-        matchedTextNode.splitText(matchedText.length);
-        var spanNode = document.createElement(HIGHLIGHT_TAG); 
-        spanNode.className = HIGHLIGHT_CLASS;
-        spanNode.style.backgroundColor = highlightColor;
-        spanNode.style.color = textColor;
-        spanNode.appendChild(matchedTextNode.cloneNode(true));
-        matchedTextNode.parentNode.replaceChild(spanNode, matchedTextNode);
-        searchInfo.highlightedNodes.push(spanNode);
-        searchInfo.length += 1;
-        return 1;
-      }
-    } else if (isExpandable(node)) {
-        var children = node.childNodes;
-        for (var i = 0; i < children.length; ++i) {
-          var child = children[i];
-          i += highlightRecursive(child);
-        }
-    }
-    return 0;
-  }
-  highlightRecursive(document.getElementsByTagName('body')[0]);
+  )
+  searchInfo.highlights = finder.elements;
+  searchInfo.length = finder.elements.length;
 };
 
 /* Remove all highlights from page */
 function removeHighlight() {
-  while (node = document.body.querySelector(HIGHLIGHT_TAG + '.' + HIGHLIGHT_CLASS)) {
-    node.outerHTML = node.innerHTML;
-  }
-    while (node = document.body.querySelector(HIGHLIGHT_TAG + '.' + SELECTED_CLASS)) {
-    node.outerHTML = node.innerHTML;
+  if (finder) {
+    finder.revert();
   }
 };
 
@@ -112,22 +85,41 @@ function scrollToElement(element) {
     window.scrollTo( 0, Math.max(top, window.pageYOffset - (window.innerHeight/2))) ;
 }
 
-/* Select first regex match on page */
+/* Select first regex match after selection on page */
 function selectFirstNode(selectedColor) {
-  var length =  searchInfo.length;
-  if(length > 0) {
-    searchInfo.highlightedNodes[0].className = SELECTED_CLASS;
-    searchInfo.highlightedNodes[0].style.backgroundColor = selectedColor;
-    scrollToElement(searchInfo.highlightedNodes[0]);
+  if (searchInfo.highlights.length === 0) {
+    return;
   }
+
+  function selectIndex(index) {
+    searchInfo.selectedIndex = index;
+    searchInfo.highlights[index].forEach((e) => { e.className = SELECTED_CLASS; });
+    scrollToElement(searchInfo.highlights[index][0]);
+  }
+
+  if (getSelection().anchorNode) {
+    function path(e) {
+      return e.parentNode === null ? [] : path(e.parentNode).concat([Array.prototype.indexOf.call(e.parentNode.childNodes, e)]);
+    }
+
+    var selection = path(getSelection().anchorNode)
+    var index = searchInfo.highlights.findIndex((h) => path(h[0]) > selection);
+    if (index !== -1) {
+      selectIndex(index);
+      return;
+    }
+  }
+
+  selectIndex(0);
 }
 
 /* Helper for selecting a regex matched element */
 function selectNode(highlightedColor, selectedColor, getNext) {
   var length = searchInfo.length;
   if(length > 0) {
-    searchInfo.highlightedNodes[searchInfo.selectedIndex].className = HIGHLIGHT_CLASS;
-    searchInfo.highlightedNodes[searchInfo.selectedIndex].style.backgroundColor = highlightedColor;
+    searchInfo.highlights[searchInfo.selectedIndex].forEach(function(n) {
+      n.className = HIGHLIGHT_CLASS;
+    });
       if(getNext) {
         if(searchInfo.selectedIndex === length - 1) {
           searchInfo.selectedIndex = 0; 
@@ -141,10 +133,11 @@ function selectNode(highlightedColor, selectedColor, getNext) {
           searchInfo.selectedIndex -= 1;
         }
       }
-    searchInfo.highlightedNodes[searchInfo.selectedIndex].className = SELECTED_CLASS;
-    searchInfo.highlightedNodes[searchInfo.selectedIndex].style.backgroundColor = selectedColor;
+    searchInfo.highlights[searchInfo.selectedIndex].forEach(function(n) {
+      n.className = SELECTED_CLASS;
+    });
     returnSearchInfo('selectNode');
-    scrollToElement(searchInfo.highlightedNodes[searchInfo.selectedIndex]);
+    scrollToElement(searchInfo.highlights[searchInfo.selectedIndex][0]);
   }
 }
 /* Forward cycle through regex matched elements */
@@ -181,7 +174,7 @@ function search(regexString, configurationChanged) {
       function(result) {
         initSearchInfo(regexString);
         if(result.caseInsensitive){
-          regex = new RegExp(regexString, 'i');
+          regex = new RegExp(regexString, 'gi');
         }
         highlight(regex, result.highlightColor, result.selectedColor, result.textColor, result.maxResults);
         selectFirstNode(result.selectedColor);
@@ -252,4 +245,17 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 
 /*** INIT ***/
 initSearchInfo();
+
+chrome.storage.local.get({
+  'highlightColor' : DEFAULT_HIGHLIGHT_COLOR,
+  'selectedColor' : DEFAULT_SELECTED_COLOR,
+  'textColor' : DEFAULT_TEXT_COLOR,
+}, function(result) {
+  var css = document.createElement("style");
+  css.type = "text/css";
+  css.innerHTML =
+  "." + HIGHLIGHT_CLASS + " { background: " + result.highlightColor + "; color: " + result.textColor + " }\n" +
+  "." + SELECTED_CLASS + " { background: " + result.selectedColor + "; color: " + result.textColor + " }";
+  document.body.appendChild(css);
+});
 /*** INIT ***/

--- a/src/js/findAndReplaceDOMText.js
+++ b/src/js/findAndReplaceDOMText.js
@@ -1,0 +1,642 @@
+/**
+ * findAndReplaceDOMText v 0.4.5
+ * @author James Padolsey http://james.padolsey.com
+ * @license http://unlicense.org/UNLICENSE
+ *
+ * Matches the text of a DOM node against a regular expression
+ * and replaces each match (or node-separated portions of the match)
+ * in the specified element.
+ */
+ (function (root, factory) {
+     if (typeof module === 'object' && module.exports) {
+         // Node/CommonJS
+         module.exports = factory();
+     } else if (typeof define === 'function' && define.amd) {
+         // AMD. Register as an anonymous module.
+         define(factory);
+     } else {
+         // Browser globals
+         root.findAndReplaceDOMText = factory();
+     }
+ }(this, function factory() {
+
+	var PORTION_MODE_RETAIN = 'retain';
+	var PORTION_MODE_FIRST = 'first';
+
+	var doc = document;
+	var hasOwn = {}.hasOwnProperty;
+
+	function escapeRegExp(s) {
+		return String(s).replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1');
+	}
+
+	function exposed() {
+		// Try deprecated arg signature first:
+		return deprecated.apply(null, arguments) || findAndReplaceDOMText.apply(null, arguments);
+	}
+
+	function deprecated(regex, node, replacement, captureGroup, elFilter) {
+		if ((node && !node.nodeType) && arguments.length <= 2) {
+			return false;
+		}
+		var isReplacementFunction = typeof replacement == 'function';
+
+		if (isReplacementFunction) {
+			replacement = (function(original) {
+				return function(portion, match) {
+					return original(portion.text, match.startIndex);
+				};
+			}(replacement));
+		}
+
+		// Awkward support for deprecated argument signature (<0.4.0)
+		var instance = findAndReplaceDOMText(node, {
+
+			find: regex,
+
+			wrap: isReplacementFunction ? null : replacement,
+			replace: isReplacementFunction ? replacement : '$' + (captureGroup || '&'),
+
+			prepMatch: function(m, mi) {
+
+				// Support captureGroup (a deprecated feature)
+
+				if (!m[0]) throw 'findAndReplaceDOMText cannot handle zero-length matches';
+
+				if (captureGroup > 0) {
+					var cg = m[captureGroup];
+					m.index += m[0].indexOf(cg);
+					m[0] = cg;
+				}
+
+				m.endIndex = m.index + m[0].length;
+				m.startIndex = m.index;
+				m.index = mi;
+
+				return m;
+			},
+			filterElements: elFilter
+		});
+
+		exposed.revert = function() {
+			return instance.revert();
+		};
+
+		return true;
+	}
+
+	/**
+	 * findAndReplaceDOMText
+	 *
+	 * Locates matches and replaces with replacementNode
+	 *
+	 * @param {Node} node Element or Text node to search within
+	 * @param {RegExp} options.find The regular expression to match
+	 * @param {String|Element} [options.wrap] A NodeName, or a Node to clone
+	 * @param {String} [options.wrapClass] A classname to append to the wrapping element
+	 * @param {String|Function} [options.replace='$&'] What to replace each match with
+	 * @param {Function} [options.filterElements] A Function to be called to check whether to
+	 *	process an element. (returning true = process element,
+	 *	returning false = avoid element)
+	 */
+	function findAndReplaceDOMText(node, options) {
+		return new Finder(node, options);
+	}
+
+	exposed.NON_PROSE_ELEMENTS = {
+		br:1, hr:1,
+		// Media / Source elements:
+		script:1, style:1, img:1, video:1, audio:1, canvas:1, svg:1, map:1, object:1,
+		// Input elements
+		input:1, textarea:1, select:1, option:1, optgroup: 1, button:1
+	};
+
+	exposed.NON_CONTIGUOUS_PROSE_ELEMENTS = {
+
+		// Elements that will not contain prose or block elements where we don't
+		// want prose to be matches across element borders:
+
+		// Block Elements
+		address:1, article:1, aside:1, blockquote:1, dd:1, div:1,
+		dl:1, fieldset:1, figcaption:1, figure:1, footer:1, form:1, h1:1, h2:1, h3:1,
+		h4:1, h5:1, h6:1, header:1, hgroup:1, hr:1, main:1, nav:1, noscript:1, ol:1,
+		output:1, p:1, pre:1, section:1, ul:1,
+		// Other misc. elements that are not part of continuous inline prose:
+		br:1, li: 1, summary: 1, dt:1, details:1, rp:1, rt:1, rtc:1,
+		// Media / Source elements:
+		script:1, style:1, img:1, video:1, audio:1, canvas:1, svg:1, map:1, object:1,
+		// Input elements
+		input:1, textarea:1, select:1, option:1, optgroup:1, button:1,
+		// Table related elements:
+		table:1, tbody:1, thead:1, th:1, tr:1, td:1, caption:1, col:1, tfoot:1, colgroup:1
+
+	};
+
+	exposed.NON_INLINE_PROSE = function(el) {
+		return hasOwn.call(exposed.NON_CONTIGUOUS_PROSE_ELEMENTS, el.nodeName.toLowerCase());
+	};
+
+	// Presets accessed via `options.preset` when calling findAndReplaceDOMText():
+	exposed.PRESETS = {
+		prose: {
+			forceContext: exposed.NON_INLINE_PROSE,
+			filterElements: function(el) {
+				return !hasOwn.call(exposed.NON_PROSE_ELEMENTS, el.nodeName.toLowerCase());
+			}
+		}
+	};
+
+	exposed.Finder = Finder;
+
+	/**
+	 * Finder -- encapsulates logic to find and replace.
+	 */
+	function Finder(node, options) {
+
+		var preset = options.preset && exposed.PRESETS[options.preset];
+
+		options.portionMode = options.portionMode || PORTION_MODE_RETAIN;
+
+		if (preset) {
+			for (var i in preset) {
+				if (hasOwn.call(preset, i) && !hasOwn.call(options, i)) {
+					options[i] = preset[i];
+				}
+			}
+		}
+
+		this.node = node;
+		this.options = options;
+
+		// Enable match-preparation method to be passed as option:
+		this.prepMatch = options.prepMatch || this.prepMatch;
+
+		this.reverts = [];
+
+		this.elements = [];
+
+		this.matches = this.search();
+
+		if (this.matches.length) {
+			this.processMatches();
+		}
+
+	}
+
+	Finder.prototype = {
+
+		/**
+		 * Searches for all matches that comply with the instance's 'match' option
+		 */
+		search: function() {
+
+			var match;
+			var matchIndex = 0;
+			var offset = 0;
+			var regex = this.options.find;
+			var textAggregation = this.getAggregateText();
+			var matches = [];
+			var self = this;
+
+			regex = typeof regex === 'string' ? RegExp(escapeRegExp(regex), 'g') : regex;
+
+			matchAggregation(textAggregation);
+
+			function matchAggregation(textAggregation) {
+				for (var i = 0, l = textAggregation.length; i < l; ++i) {
+
+					var text = textAggregation[i];
+
+					if (typeof text !== 'string') {
+						// Deal with nested contexts: (recursive)
+						matchAggregation(text);
+						continue;
+					}
+
+					if (regex.global) {
+						while (match = regex.exec(text)) {
+							matches.push(self.prepMatch(match, matchIndex++, offset));
+						}
+					} else {
+						if (match = text.match(regex)) {
+							matches.push(self.prepMatch(match, 0, offset));
+						}
+					}
+
+					offset += text.length;
+				}
+			}
+
+			return matches;
+
+		},
+
+		/**
+		 * Prepares a single match with useful meta info:
+		 */
+		prepMatch: function(match, matchIndex, characterOffset) {
+
+			if (!match[0]) {
+				throw new Error('findAndReplaceDOMText cannot handle zero-length matches');
+			}
+
+			match.endIndex = characterOffset + match.index + match[0].length;
+			match.startIndex = characterOffset + match.index;
+			match.index = matchIndex;
+
+			return match;
+		},
+
+		/**
+		 * Gets aggregate text within subject node
+		 */
+		getAggregateText: function() {
+
+			var elementFilter = this.options.filterElements;
+			var forceContext = this.options.forceContext;
+
+			return getText(this.node);
+
+			/**
+			 * Gets aggregate text of a node without resorting
+			 * to broken innerText/textContent
+			 */
+			function getText(node) {
+
+				if (node.nodeType === Node.TEXT_NODE) {
+					return [node.data];
+				}
+
+				if (elementFilter && !elementFilter(node)) {
+					return [];
+				}
+
+				var txt = [''];
+				var i = 0;
+
+				if (node = node.firstChild) do {
+
+					if (node.nodeType === Node.TEXT_NODE) {
+						txt[i] += node.data;
+						continue;
+					}
+
+					var innerText = getText(node);
+
+					if (
+						forceContext &&
+						node.nodeType === Node.ELEMENT_NODE &&
+						(forceContext === true || forceContext(node))
+					) {
+						txt[++i] = innerText;
+						txt[++i] = '';
+					} else {
+						if (typeof innerText[0] === 'string') {
+							// Bridge nested text-node data so that they're
+							// not considered their own contexts:
+							// I.e. ['some', ['thing']] -> ['something']
+							txt[i] += innerText.shift();
+						}
+						if (innerText.length) {
+							txt[++i] = innerText;
+							txt[++i] = '';
+						}
+					}
+				} while (node = node.nextSibling);
+
+				return txt;
+
+			}
+
+		},
+
+		/**
+		 * Steps through the target node, looking for matches, and
+		 * calling replaceFn when a match is found.
+		 */
+		processMatches: function() {
+
+			var matches = this.matches;
+			var node = this.node;
+			var elementFilter = this.options.filterElements;
+
+			var startPortion,
+				endPortion,
+				innerPortions = [],
+				curNode = node,
+				match = matches.shift(),
+				atIndex = 0, // i.e. nodeAtIndex
+				matchIndex = 0,
+				portionIndex = 0,
+				doAvoidNode,
+				nodeStack = [node];
+
+			out: while (true) {
+
+				if (curNode.nodeType === Node.TEXT_NODE) {
+
+					if (!endPortion && curNode.length + atIndex >= match.endIndex) {
+
+						// We've found the ending
+						endPortion = {
+							node: curNode,
+							index: portionIndex++,
+							text: curNode.data.substring(match.startIndex - atIndex, match.endIndex - atIndex),
+							indexInMatch: atIndex - match.startIndex,
+							indexInNode: match.startIndex - atIndex, // always zero for end-portions
+							endIndexInNode: match.endIndex - atIndex,
+							isEnd: true
+						};
+
+					} else if (startPortion) {
+						// Intersecting node
+						innerPortions.push({
+							node: curNode,
+							index: portionIndex++,
+							text: curNode.data,
+							indexInMatch: atIndex - match.startIndex,
+							indexInNode: 0 // always zero for inner-portions
+						});
+					}
+
+					if (!startPortion && curNode.length + atIndex > match.startIndex) {
+						// We've found the match start
+						startPortion = {
+							node: curNode,
+							index: portionIndex++,
+							indexInMatch: 0,
+							indexInNode: match.startIndex - atIndex,
+							endIndexInNode: match.endIndex - atIndex,
+							text: curNode.data.substring(match.startIndex - atIndex, match.endIndex - atIndex)
+						};
+					}
+
+					atIndex += curNode.data.length;
+
+				}
+
+				doAvoidNode = curNode.nodeType === Node.ELEMENT_NODE && elementFilter && !elementFilter(curNode);
+
+				if (startPortion && endPortion) {
+
+					curNode = this.replaceMatch(match, startPortion, innerPortions, endPortion);
+
+					// processMatches has to return the node that replaced the endNode
+					// and then we step back so we can continue from the end of the
+					// match:
+
+					atIndex -= (endPortion.node.data.length - endPortion.endIndexInNode);
+
+					startPortion = null;
+					endPortion = null;
+					innerPortions = [];
+					match = matches.shift();
+					portionIndex = 0;
+					matchIndex++;
+
+					if (!match) {
+						break; // no more matches
+					}
+
+				} else if (
+					!doAvoidNode &&
+					(curNode.firstChild || curNode.nextSibling)
+				) {
+					// Move down or forward:
+					if (curNode.firstChild) {
+						nodeStack.push(curNode);
+						curNode = curNode.firstChild;
+					} else {
+						curNode = curNode.nextSibling;
+					}
+					continue;
+				}
+
+				// Move forward or up:
+				while (true) {
+					if (curNode.nextSibling) {
+						curNode = curNode.nextSibling;
+						break;
+					}
+					curNode = nodeStack.pop();
+					if (curNode === node) {
+						break out;
+					}
+				}
+
+			}
+
+		},
+
+		/**
+		 * Reverts ... TODO
+		 */
+		revert: function() {
+			// Reversion occurs backwards so as to avoid nodes subsequently
+			// replaced during the matching phase (a forward process):
+			for (var l = this.reverts.length; l--;) {
+				this.reverts[l]();
+			}
+			this.reverts = [];
+			this.elements = [];
+		},
+
+		// Array of matches, where each match is an array of elements
+		elements: this.elements,
+
+		prepareReplacementString: function(string, portion, match) {
+			var portionMode = this.options.portionMode;
+			if (
+				portionMode === PORTION_MODE_FIRST &&
+				portion.indexInMatch > 0
+			) {
+				return '';
+			}
+			string = string.replace(/\$(\d+|&|`|')/g, function($0, t) {
+				var replacement;
+				switch(t) {
+					case '&':
+						replacement = match[0];
+						break;
+					case '`':
+						replacement = match.input.substring(0, match.startIndex);
+						break;
+					case '\'':
+						replacement = match.input.substring(match.endIndex);
+						break;
+					default:
+						replacement = match[+t];
+				}
+				return replacement;
+			});
+
+			if (portionMode === PORTION_MODE_FIRST) {
+				return string;
+			}
+
+			if (portion.isEnd) {
+				return string.substring(portion.indexInMatch);
+			}
+
+			return string.substring(portion.indexInMatch, portion.indexInMatch + portion.text.length);
+		},
+
+		getPortionReplacementNode: function(portion, match) {
+
+			var replacement = this.options.replace || '$&';
+			var wrapper = this.options.wrap;
+			var wrapperClass = this.options.wrapClass;
+
+			if (wrapper && wrapper.nodeType) {
+				// Wrapper has been provided as a stencil-node for us to clone:
+				var clone = doc.createElement('div');
+				clone.innerHTML = wrapper.outerHTML || new XMLSerializer().serializeToString(wrapper);
+				wrapper = clone.firstChild;
+			}
+
+			if (typeof replacement == 'function') {
+				replacement = replacement(portion, match);
+				if (replacement && replacement.nodeType) {
+					return replacement;
+				}
+				return doc.createTextNode(String(replacement));
+			}
+
+			var el = typeof wrapper == 'string' ? doc.createElement(wrapper) : wrapper;
+
+ 			if (el && wrapperClass) {
+				el.className = wrapperClass;
+			}
+
+			replacement = doc.createTextNode(
+				this.prepareReplacementString(
+					replacement, portion, match
+				)
+			);
+
+			if (!replacement.data) {
+				return replacement;
+			}
+
+			if (!el) {
+				return replacement;
+			}
+
+			el.appendChild(replacement);
+
+			return el;
+		},
+
+		replaceMatch: function(match, startPortion, innerPortions, endPortion) {
+
+			var matchStartNode = startPortion.node;
+			var matchEndNode = endPortion.node;
+
+			var precedingTextNode;
+			var followingTextNode;
+
+			if (matchStartNode === matchEndNode) {
+
+				var node = matchStartNode;
+
+				if (startPortion.indexInNode > 0) {
+					// Add `before` text node (before the match)
+					precedingTextNode = doc.createTextNode(node.data.substring(0, startPortion.indexInNode));
+					node.parentNode.insertBefore(precedingTextNode, node);
+				}
+
+				// Create the replacement node:
+				var newNode = this.getPortionReplacementNode(
+					endPortion,
+					match
+				);
+
+				node.parentNode.insertBefore(newNode, node);
+
+				if (endPortion.endIndexInNode < node.length) { // ?????
+					// Add `after` text node (after the match)
+					followingTextNode = doc.createTextNode(node.data.substring(endPortion.endIndexInNode));
+					node.parentNode.insertBefore(followingTextNode, node);
+				}
+
+				node.parentNode.removeChild(node);
+
+				this.reverts.push(function() {
+					if (precedingTextNode === newNode.previousSibling) {
+						precedingTextNode.parentNode.removeChild(precedingTextNode);
+					}
+					if (followingTextNode === newNode.nextSibling) {
+						followingTextNode.parentNode.removeChild(followingTextNode);
+					}
+					newNode.parentNode.replaceChild(node, newNode);
+				});
+
+				this.elements.push([newNode]);
+
+				return newNode;
+
+			} else {
+				// Replace matchStartNode -> [innerMatchNodes...] -> matchEndNode (in that order)
+
+
+				precedingTextNode = doc.createTextNode(
+					matchStartNode.data.substring(0, startPortion.indexInNode)
+				);
+
+				followingTextNode = doc.createTextNode(
+					matchEndNode.data.substring(endPortion.endIndexInNode)
+				);
+
+				var firstNode = this.getPortionReplacementNode(
+					startPortion,
+					match
+				);
+
+				var innerNodes = [];
+
+				for (var i = 0, l = innerPortions.length; i < l; ++i) {
+					var portion = innerPortions[i];
+					var innerNode = this.getPortionReplacementNode(
+						portion,
+						match
+					);
+					portion.node.parentNode.replaceChild(innerNode, portion.node);
+					this.reverts.push((function(portion, innerNode) {
+						return function() {
+							innerNode.parentNode.replaceChild(portion.node, innerNode);
+						};
+					}(portion, innerNode)));
+					innerNodes.push(innerNode);
+				}
+
+				var lastNode = this.getPortionReplacementNode(
+					endPortion,
+					match
+				);
+
+				this.elements.push([firstNode].concat(innerNodes).concat([lastNode]));
+
+				matchStartNode.parentNode.insertBefore(precedingTextNode, matchStartNode);
+				matchStartNode.parentNode.insertBefore(firstNode, matchStartNode);
+				matchStartNode.parentNode.removeChild(matchStartNode);
+
+				matchEndNode.parentNode.insertBefore(lastNode, matchEndNode);
+				matchEndNode.parentNode.insertBefore(followingTextNode, matchEndNode);
+				matchEndNode.parentNode.removeChild(matchEndNode);
+
+				this.reverts.push(function() {
+					precedingTextNode.parentNode.removeChild(precedingTextNode);
+					firstNode.parentNode.replaceChild(matchStartNode, firstNode);
+					followingTextNode.parentNode.removeChild(followingTextNode);
+					lastNode.parentNode.replaceChild(matchEndNode, lastNode);
+				});
+
+				return lastNode;
+			}
+		}
+
+	};
+
+	return exposed;
+
+}));

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -267,6 +267,9 @@ onkeydown = onkeyup = function(e) {
         }
       } else if (map[16] && map[13]) { //SHIFT + ENTER
         selectPrev();
+      } else if (map[27]) { //ESCAPE
+        document.getElementById('inputRegex').value = "";
+        passInputToContentScript();
       }
     }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -40,7 +40,7 @@
   "content_scripts": [
     {
       "matches": ["http://*/*", "https://*/*", "file://*/*"],
-      "js": ["js/content.js"]
+      "js": ["js/content.js", "js/findAndReplaceDOMText.js"]
     }
   ],
   "options_page": "options.html"


### PR DESCRIPTION
Previously, the entire regex had to match within a single element, which made this extension pretty much unusable on pages with lots of styling and elements (e.g. code documentation).

This PR uses [findAndReplaceDOMText][1] with a [modification][2] to support matches that cross element boundaries:

![image](https://user-images.githubusercontent.com/1387653/26918673-3570470c-4bf0-11e7-8ff4-f19e4ec323e6.png)

[1]: https://github.com/padolsey/findAndReplaceDOMText
[2]: https://github.com/padolsey/findAndReplaceDOMText/pull/61