### PR TITLE
remove unused args, cleanup

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -15,38 +15,37 @@ var DEFAULT_CASE_INSENSITIVE = false;
 /*** VARIABLES ***/
 var searchInfo;
 /*** VARIABLES ***/
-                     
+
 /*** LIBRARY FUNCTIONS ***/
 Element.prototype.documentOffsetTop = function () {
-  return this.offsetTop + ( this.offsetParent ? this.offsetParent.documentOffsetTop() : 0 );
+  return this.offsetTop + (this.offsetParent ? this.offsetParent.documentOffsetTop() : 0);
 };
-Element.prototype.visible = function() {
-    return (!window.getComputedStyle(this) || window.getComputedStyle(this).getPropertyValue('display') == '' || 
-           window.getComputedStyle(this).getPropertyValue('display') != 'none')
+Element.prototype.visible = function () {
+  return (!window.getComputedStyle(this) || window.getComputedStyle(this).getPropertyValue('display') == '' ||
+    window.getComputedStyle(this).getPropertyValue('display') != 'none')
 }
 /*** LIBRARY FUNCTIONS ***/
-
 
 /*** FUNCTIONS ***/
 /* Initialize search information for this tab */
 function initSearchInfo(pattern) {
   var pattern = typeof pattern !== 'undefined' ? pattern : '';
   searchInfo = {
-    regexString : pattern,
-    selectedIndex : 0,
-    highlightedNodes : [],
-    length : 0
+    regexString: pattern,
+    selectedIndex: 0,
+    highlightedNodes: [],
+    length: 0
   }
 }
 
 /* Send message with search information for this tab */
 function returnSearchInfo(cause) {
   chrome.runtime.sendMessage({
-    'message' : 'returnSearchInfo',
-    'regexString' : searchInfo.regexString,
-    'currentSelection' : searchInfo.selectedIndex,
-    'numResults' : searchInfo.length,
-    'cause' : cause
+    'message': 'returnSearchInfo',
+    'regexString': searchInfo.regexString,
+    'currentSelection': searchInfo.selectedIndex,
+    'numResults': searchInfo.length,
+    'cause': cause
   });
 }
 
@@ -57,14 +56,14 @@ function isTextNode(node) {
 
 /* Check if the given node is an expandable node that will yield text nodes */
 function isExpandable(node) {
-  return node && node.nodeType === ELEMENT_NODE_TYPE && node.childNodes && 
-         !UNEXPANDABLE.test(node.tagName) && node.visible();
+  return node && node.nodeType === ELEMENT_NODE_TYPE && node.childNodes &&
+    !UNEXPANDABLE.test(node.tagName) && node.visible();
 }
 
 /* Highlight all text that matches regex */
-function highlight(regex, highlightColor, selectedColor, textColor, maxResults) {
+function highlight(regex, highlightColor, textColor, maxResults) {
   function highlightRecursive(node) {
-    if(searchInfo.length >= maxResults){
+    if (searchInfo.length >= maxResults) {
       return;
     }
     if (isTextNode(node)) {
@@ -73,7 +72,7 @@ function highlight(regex, highlightColor, selectedColor, textColor, maxResults) 
         var matchedText = node.data.match(regex)[0];
         var matchedTextNode = node.splitText(index);
         matchedTextNode.splitText(matchedText.length);
-        var spanNode = document.createElement(HIGHLIGHT_TAG); 
+        var spanNode = document.createElement(HIGHLIGHT_TAG);
         spanNode.className = HIGHLIGHT_CLASS;
         spanNode.style.backgroundColor = highlightColor;
         spanNode.style.color = textColor;
@@ -84,11 +83,11 @@ function highlight(regex, highlightColor, selectedColor, textColor, maxResults) 
         return 1;
       }
     } else if (isExpandable(node)) {
-        var children = node.childNodes;
-        for (var i = 0; i < children.length; ++i) {
-          var child = children[i];
-          i += highlightRecursive(child);
-        }
+      var children = node.childNodes;
+      for (var i = 0; i < children.length; ++i) {
+        var child = children[i];
+        i += highlightRecursive(child);
+      }
     }
     return 0;
   }
@@ -100,22 +99,22 @@ function removeHighlight() {
   while (node = document.body.querySelector(HIGHLIGHT_TAG + '.' + HIGHLIGHT_CLASS)) {
     node.outerHTML = node.innerHTML;
   }
-    while (node = document.body.querySelector(HIGHLIGHT_TAG + '.' + SELECTED_CLASS)) {
+  while (node = document.body.querySelector(HIGHLIGHT_TAG + '.' + SELECTED_CLASS)) {
     node.outerHTML = node.innerHTML;
   }
 };
 
 /* Scroll page to given element */
 function scrollToElement(element) {
-    element.scrollIntoView(); 
-    var top = element.documentOffsetTop() - ( window.innerHeight / 2 );
-    window.scrollTo( 0, Math.max(top, window.pageYOffset - (window.innerHeight/2))) ;
+  element.scrollIntoView();
+  var top = element.documentOffsetTop() - (window.innerHeight / 2);
+  window.scrollTo(0, Math.max(top, window.pageYOffset - (window.innerHeight / 2)));
 }
 
 /* Select first regex match on page */
 function selectFirstNode(selectedColor) {
-  var length =  searchInfo.length;
-  if(length > 0) {
+  var length = searchInfo.length;
+  if (length > 0) {
     searchInfo.highlightedNodes[0].className = SELECTED_CLASS;
     searchInfo.highlightedNodes[0].style.backgroundColor = selectedColor;
     parentNode = searchInfo.highlightedNodes[0].parentNode;
@@ -131,22 +130,22 @@ function selectFirstNode(selectedColor) {
 /* Helper for selecting a regex matched element */
 function selectNode(highlightedColor, selectedColor, getNext) {
   var length = searchInfo.length;
-  if(length > 0) {
+  if (length > 0) {
     searchInfo.highlightedNodes[searchInfo.selectedIndex].className = HIGHLIGHT_CLASS;
     searchInfo.highlightedNodes[searchInfo.selectedIndex].style.backgroundColor = highlightedColor;
-      if(getNext) {
-        if(searchInfo.selectedIndex === length - 1) {
-          searchInfo.selectedIndex = 0; 
-        } else {
-          searchInfo.selectedIndex += 1;
-        }
+    if (getNext) {
+      if (searchInfo.selectedIndex === length - 1) {
+        searchInfo.selectedIndex = 0;
       } else {
-        if(searchInfo.selectedIndex === 0) {
-          searchInfo.selectedIndex = length - 1; 
-        } else {
-          searchInfo.selectedIndex -= 1;
-        }
+        searchInfo.selectedIndex += 1;
       }
+    } else {
+      if (searchInfo.selectedIndex === 0) {
+        searchInfo.selectedIndex = length - 1;
+      } else {
+        searchInfo.selectedIndex -= 1;
+      }
+    }
     searchInfo.highlightedNodes[searchInfo.selectedIndex].className = SELECTED_CLASS;
     searchInfo.highlightedNodes[searchInfo.selectedIndex].style.backgroundColor = selectedColor;
     parentNode = searchInfo.highlightedNodes[searchInfo.selectedIndex].parentNode;
@@ -161,7 +160,7 @@ function selectNode(highlightedColor, selectedColor, getNext) {
 }
 /* Forward cycle through regex matched elements */
 function selectNextNode(highlightedColor, selectedColor) {
-  selectNode(highlightedColor, selectedColor, true); 
+  selectNode(highlightedColor, selectedColor, true);
 }
 
 /* Backward cycle through regex matched elements */
@@ -171,10 +170,10 @@ function selectPrevNode(highlightedColor, selectedColor) {
 
 /* Validate that a given pattern string is a valid regex */
 function validateRegex(pattern) {
-  try{
+  try {
     var regex = new RegExp(pattern);
     return regex;
-  } catch(e) {
+  } catch (e) {
     return false;
   }
 }
@@ -185,14 +184,15 @@ function search(regexString, configurationChanged) {
   if (regex && regexString != '' && (configurationChanged || regexString !== searchInfo.regexString)) { // new valid regex string
     removeHighlight();
     chrome.storage.local.get({
-      'highlightColor' : DEFAULT_HIGHLIGHT_COLOR,
-      'selectedColor' : DEFAULT_SELECTED_COLOR,
-      'textColor' : DEFAULT_TEXT_COLOR,
-      'maxResults' : DEFAULT_MAX_RESULTS,
-      'caseInsensitive' : DEFAULT_CASE_INSENSITIVE}, 
-      function(result) {
+      'highlightColor': DEFAULT_HIGHLIGHT_COLOR,
+      'selectedColor': DEFAULT_SELECTED_COLOR,
+      'textColor': DEFAULT_TEXT_COLOR,
+      'maxResults': DEFAULT_MAX_RESULTS,
+      'caseInsensitive': DEFAULT_CASE_INSENSITIVE
+    },
+      function (result) {
         initSearchInfo(regexString);
-        if(result.caseInsensitive){
+        if (result.caseInsensitive) {
           regex = new RegExp(regexString, 'i');
         }
         highlight(regex, result.highlightColor, result.selectedColor, result.textColor, result.maxResults);
@@ -202,9 +202,10 @@ function search(regexString, configurationChanged) {
     );
   } else if (regex && regexString != '' && regexString === searchInfo.regexString) { // elements are already highlighted
     chrome.storage.local.get({
-      'highlightColor' : DEFAULT_HIGHLIGHT_COLOR,
-      'selectedColor' : DEFAULT_SELECTED_COLOR}, 
-      function(result) {
+      'highlightColor': DEFAULT_HIGHLIGHT_COLOR,
+      'selectedColor': DEFAULT_SELECTED_COLOR
+    },
+      function (result) {
         selectNextNode(result.highlightColor, result.selectedColor);
       }
     );
@@ -218,17 +219,17 @@ function search(regexString, configurationChanged) {
 
 /*** LISTENERS ***/
 /* Received search message, find regex matches */
-chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function (request, sendResponse) {
   if ('search' == request.message) {
     search(request.regexString, request.configurationChanged);
   }
   /* Received selectNextNode message, select next regex match */
   else if ('selectNextNode' == request.message) {
     chrome.storage.local.get({
-      'highlightColor' : DEFAULT_HIGHLIGHT_COLOR,
-      'selectedColor' : DEFAULT_SELECTED_COLOR
-      }, 
-      function(result) {
+      'highlightColor': DEFAULT_HIGHLIGHT_COLOR,
+      'selectedColor': DEFAULT_SELECTED_COLOR
+    },
+      function (result) {
         selectNextNode(result.highlightColor, result.selectedColor);
       }
     );
@@ -236,10 +237,10 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   /* Received selectPrevNode message, select previous regex match */
   else if ('selectPrevNode' == request.message) {
     chrome.storage.local.get({
-      'highlightColor' : DEFAULT_HIGHLIGHT_COLOR,
-      'selectedColor' : DEFAULT_SELECTED_COLOR
-      }, 
-      function(result) {
+      'highlightColor': DEFAULT_HIGHLIGHT_COLOR,
+      'selectedColor': DEFAULT_SELECTED_COLOR
+    },
+      function (result) {
         selectPrevNode(result.highlightColor, result.selectedColor);
       }
     );
@@ -260,12 +261,11 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
   }
   /* Received getSearchInfo message, return search information for this tab */
   else if ('getSearchInfo' == request.message) {
-    sendResponse({message: "I'm alive!"});
+    sendResponse({ message: "I'm alive!" });
     returnSearchInfo('getSearchInfo');
   }
 });
 /*** LISTENERS ***/
-
 
 /*** INIT ***/
 initSearchInfo();


### PR DESCRIPTION
Removed unused args
Styling changes for consistency (mostly white space: indentation, `if()` vs `if ()`, trailing spaces, etc)

I tried to keep this light, there are other changes to content.js I considered: 

- replacing the var declarations with block scoped (let and const) declarations (I wasn't sure if this was intentional to support chrome versions <40)

- removing variable assignment from while conditions in removeHighlight (line 98), I appreciate conciseness but I think you're losing readability here

- I think how you're iterating through nodes in selectNode (line 131) could probably be improved (at least to lower the line length) but I think the readability is ok here so maybe this is moot

your thoughts?